### PR TITLE
add conversations-history

### DIFF
--- a/frontend/app/(routes)/conversations-history/page.tsx
+++ b/frontend/app/(routes)/conversations-history/page.tsx
@@ -1,0 +1,10 @@
+import ConversationHistory from "@/components/ConversationHistory/idex";
+
+const page = () => {
+  return (
+    <div>
+      <ConversationHistory />
+    </div>
+  );
+};
+export default page;

--- a/frontend/components/ConversationHistory/ConversationDrawer.tsx
+++ b/frontend/components/ConversationHistory/ConversationDrawer.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState, useRef, Dispatch, SetStateAction } from "react";
+import ReactMarkdown from "react-markdown";
+import { MultiLineSkeletonLoader } from "../Loaders";
+import { cn } from "@/utils/cn";
+import { getConversation } from "@/utils/getConversation";
+import { Sheet, SheetContent } from "../ui/sheet";
+
+interface ConversationDrawerProps {
+  isDrawerOpen: boolean;
+  handleDrawerClose: Dispatch<SetStateAction<boolean>>;
+  threadId: string | null;
+}
+interface Message {
+  role: string;
+  content: { text: { value: string } }[];
+  created_at: number;
+}
+
+const ConversationDrawer: React.FC<ConversationDrawerProps> = ({
+  isDrawerOpen,
+  handleDrawerClose,
+  threadId,
+}) => {
+  const [conversation, setConversation] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    const fetchConversation = async () => {
+      if (threadId) {
+        const fetchedConversation = await getConversation(threadId);
+        const sortedMessages = fetchedConversation.sort(
+          (a: { created_at: number }, b: { created_at: number }) =>
+            a.created_at - b.created_at
+        );
+        setConversation(sortedMessages);
+      }
+      setLoading(false);
+    };
+
+    if (isDrawerOpen) {
+      fetchConversation();
+    }
+  }, [isDrawerOpen, threadId]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [conversation]);
+
+  function removeCitations(text: string) {
+    // This regex matches the pattern 【digits:digits†source】
+    const citationRegex = /【\d+:\d+†source】/g;
+    return text.replace(citationRegex, "");
+  }
+
+  return (
+    <Sheet open={isDrawerOpen} onOpenChange={handleDrawerClose}>
+      <SheetContent
+        width="ninety"
+        background="white"
+        handleDrawerClose={handleDrawerClose}
+        isDrawerOpen={isDrawerOpen}
+      >
+        {loading ? (
+          <div className="w-full mt-10">
+            <MultiLineSkeletonLoader lines={5} justifyContent="left" />
+          </div>
+        ) : (
+          <div
+            className="overflow-y-scroll overflow-x-visible h-full hide-scrollbar mt-12"
+            style={{ maxHeight: "90vh" }}
+          >
+            {conversation.map((message, index) => (
+              <div key={index} className="w-full">
+                <div
+                  className={cn("rounded-lg border border-gray-100 p-4 mb-4", {
+                    "bg-gray-100": message.role === "user",
+                  })}
+                >
+                  <div className="text-sm">
+                    <ReactMarkdown>
+                      {removeCitations(message.content[0].text.value)}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default ConversationDrawer;

--- a/frontend/components/ConversationHistory/ConversationHistoryFooter.tsx
+++ b/frontend/components/ConversationHistory/ConversationHistoryFooter.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+
+const Pagination: React.FC<{ children: React.ReactNode }> = ({ children }) => <div>{children}</div>;
+const PaginationContent: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="flex justify-center space-x-1">{children}</div>
+);
+const PaginationItem: React.FC<{ children: React.ReactNode }> = ({ children }) => <div>{children}</div>;
+const PaginationLink: React.FC<{ children: React.ReactNode; isActive: boolean; onClick: () => void }> = ({
+  children,
+  isActive,
+  onClick,
+}) => (
+  <button
+    onClick={onClick}
+    className={`px-2 py-1 sm:px-4 sm:py-2 border rounded text-xs sm:text-base ${
+      isActive ? "bg-blue-500 text-white" : "bg-white text-black"
+    }`}
+  >
+    {children}
+  </button>
+);
+
+const PaginationPrevious = ({ onClick }: { onClick: () => void }) => (
+  <button
+    onClick={onClick}
+    className="px-2 py-1 sm:px-4 sm:py-2  border rounded bg-white text-black text-sm sm:text-base"
+  >
+    Previous
+  </button>
+);
+
+const PaginationNext = ({ onClick }: { onClick: () => void }) => (
+  <button
+    onClick={onClick}
+    className="px-2 py-1 sm:px-4 sm:py-2 border rounded bg-white text-black text-sm sm:text-base"
+  >
+    Next
+  </button>
+);
+
+const PaginationEllipsis = () => (
+  <span className="px-2 py-1 sm:px-4 sm:py-2 ">...</span>
+);
+
+interface ConversationHistoryFooterProps {
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  totalPages: number;
+}
+
+const ConversationHistoryFooter: React.FC<ConversationHistoryFooterProps> = ({
+  currentPage,
+  setCurrentPage,
+  totalPages,
+}) => {
+  // Define ranges for the pagination controls
+  const shouldShowFirst = currentPage > 2;
+  const shouldShowLast = currentPage < totalPages - 1;
+
+  return (
+    <div className="absolute bottom-0 left-0 py-6 px-8 bg-white w-full shadow-lg">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => setCurrentPage(currentPage - 1)}
+            />
+          </PaginationItem>
+
+          {shouldShowFirst && (
+            <PaginationItem>
+              <PaginationLink
+                isActive={false}
+                onClick={() => setCurrentPage(1)}
+              >
+                1
+              </PaginationLink>
+            </PaginationItem>
+          )}
+
+          {shouldShowFirst && (
+            <PaginationItem>
+              <PaginationEllipsis />
+            </PaginationItem>
+          )}
+
+          {currentPage > 1 && (
+            <PaginationItem>
+              <PaginationLink
+                isActive={false}
+                onClick={() => setCurrentPage(currentPage - 1)}
+              >
+                {currentPage - 1}
+              </PaginationLink>
+            </PaginationItem>
+          )}
+
+          <PaginationItem>
+            <PaginationLink
+              onClick={() => setCurrentPage(currentPage)}
+              isActive
+            >
+              {currentPage}
+            </PaginationLink>
+          </PaginationItem>
+
+          {currentPage < totalPages && (
+            <PaginationItem>
+              <PaginationLink
+                isActive={false}
+                onClick={() => setCurrentPage(currentPage + 1)}
+              >
+                {currentPage + 1}
+              </PaginationLink>
+            </PaginationItem>
+          )}
+
+          {shouldShowLast && (
+            <PaginationItem>
+              <PaginationEllipsis />
+            </PaginationItem>
+          )}
+
+          {shouldShowLast && (
+            <PaginationItem>
+              <PaginationLink
+                isActive={false}
+                onClick={() => setCurrentPage(totalPages)}
+              >
+                {totalPages}
+              </PaginationLink>
+            </PaginationItem>
+          )}
+
+          <PaginationItem>
+            <PaginationNext onClick={() => setCurrentPage(currentPage + 1)} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+};
+
+export default ConversationHistoryFooter;

--- a/frontend/components/ConversationHistory/ConversationSorterDropdown.tsx
+++ b/frontend/components/ConversationHistory/ConversationSorterDropdown.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import ConversationSorterItem from "./ConversationSorterItem";
+
+interface ConversationSorterDropdownProps {
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  sortMessages: (sortValue: string) => void;
+  setIsDropdownOpen: (isOpen: boolean) => void;
+}
+
+const ConversationSorterDropdown: React.FC<ConversationSorterDropdownProps> = ({
+  isOpen,
+  setOpen,
+  sortMessages,
+  setIsDropdownOpen,
+}) => {
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setOpen}>
+      <DropdownMenuTrigger />
+
+      <DropdownMenuContent className="mt-3 p-2 text-xs flex flex-col ">
+        <ConversationSorterItem
+          imgSrc="/clock.png"
+          sortMessages={sortMessages}
+          sortValue="latest"
+          title="Latest"
+          setIsDropdownOpen={setIsDropdownOpen}
+        />
+        <ConversationSorterItem
+          imgSrc="/most.png"
+          sortMessages={sortMessages}
+          sortValue="most"
+          title="Most messages first"
+          setIsDropdownOpen={setIsDropdownOpen}
+        />
+        <ConversationSorterItem
+          imgSrc="/least.png"
+          sortMessages={sortMessages}
+          sortValue="least"
+          title="Least messages first"
+          setIsDropdownOpen={setIsDropdownOpen}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ConversationSorterDropdown;

--- a/frontend/components/ConversationHistory/ConversationSorterItem.tsx
+++ b/frontend/components/ConversationHistory/ConversationSorterItem.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Image from "next/image";
+
+interface ConversationSorterItemProps {
+  imgSrc: string;
+  sortMessages: (value: string) => void;
+  sortValue: string;
+  title: string;
+  setIsDropdownOpen: (value: boolean) => void;
+}
+
+const ConversationSorterItem = ({
+  imgSrc,
+  sortMessages,
+  sortValue,
+  title,
+  setIsDropdownOpen,
+}: ConversationSorterItemProps) => {
+  return (
+    <div
+      onClick={() => {
+        sortMessages(sortValue);
+        setIsDropdownOpen(false);
+      }}
+      className="cursor-pointer p-2 rounded-md hover:bg-slate-100 flex items-center gap-2"
+    >
+      <Image src={imgSrc} width={0} height={0} alt="" className="w-3 h-3" />
+      {title}
+    </div>
+  );
+};
+
+export default ConversationSorterItem;

--- a/frontend/components/ConversationHistory/ConversationTitle.tsx
+++ b/frontend/components/ConversationHistory/ConversationTitle.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import Image from "next/image";
+import ConversationSorterDropdown from "./ConversationSorterDropdown";
+
+interface ConversationTitleProps {
+  sortMessages: (value: string) => void;
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+  setIsDropdownOpen: (value: boolean) => void;
+}
+
+const ConversationTitle = ({
+  setIsDropdownOpen,
+  sortMessages,
+  isOpen,
+  setIsOpen,
+}: ConversationTitleProps) => {
+  return (
+    <div className="bg-white p-5 text-center flex justify-center shadow-lg">
+      <div className="flex justify-between lg:w-[60%] items-center">
+        <p className="font-medium">Conversation History</p>
+        <div className="flex">
+          <Image
+            src="/filter.png"
+            alt=""
+            width={10}
+            height={10}
+            className="w-4 h-4 ml-10 sm:ml-44"
+            onClick={() => setIsOpen(!isOpen)}
+          />
+          <ConversationSorterDropdown
+            isOpen={isOpen}
+            setOpen={setIsOpen}
+            sortMessages={sortMessages}
+            setIsDropdownOpen={setIsDropdownOpen}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConversationTitle;

--- a/frontend/components/ConversationHistory/ConversationsList.tsx
+++ b/frontend/components/ConversationHistory/ConversationsList.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import Image from "next/image";
+
+import { Conversation } from "@/types";
+
+import useSortedConversations from "@/hooks/useSortedConversations";
+import { MultiLineSkeletonLoader } from "../Loaders";
+
+interface ConversationsListProps {
+  sortType: string;
+  loading: boolean;
+  setIsDrawerOpen: (value: boolean) => void;
+  setSelectedConversation: any;
+  conversationsList: Conversation[];
+}
+
+const ConversationsList = ({
+  conversationsList,
+  setSelectedConversation,
+  loading,
+  setIsDrawerOpen,
+  sortType,
+}: ConversationsListProps) => {
+  const handleConversationClick = (conversation: Conversation) => {
+    setSelectedConversation(conversation.threadId);
+    setIsDrawerOpen(true);
+  };
+
+  const conversationList = useSortedConversations({
+    conversations: conversationsList,
+    sortType,
+  });
+
+  return (
+    <div className="flex flex-1 h-full overflow-y-scroll py-10 flex-col items-center p-2 sm:p-8 pb-10 sm:pb-36">
+      {loading && (
+        <div className="items-center pt-6">
+          <MultiLineSkeletonLoader lines={6} justifyContent="left" />
+        </div>
+      )}
+      {conversationList.map((conversation: Conversation, index: number) => {
+        let date = new Date(conversation.lastUpdated);
+
+        let formattedDate = date.toLocaleDateString("en-GB");
+        let formattedHour = date.toLocaleTimeString("en-US", {
+          hourCycle: "h23",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        });
+
+        return (
+          <div
+            key={index}
+            onClick={() => handleConversationClick(conversation)}
+            className="flex items-center justify-between bg-white w-[80vw] lg:w-[60%] rounded-xl px-4 sm:px-6 py-4 mb-3 text-xs sm:text-sm shadow-md cursor-pointer hover:bg-gray-100"
+          >
+            <div className="flex gap-4 sm:gap-8 items-center">
+              <Image
+                src="/conversation_chat.png"
+                alt=""
+                height={0}
+                width={0}
+                className="w-4 h-4"
+              />
+              <div className="hidden sm:block w-32"> {conversation.title}</div>
+
+              <p className=" w-24 sm:w-40"> {formattedDate}</p>
+              <div className="flex items-center justify-start gap-4">
+                {" "}
+                {formattedHour}
+                <p className="text-gray-400 text-xs">UTC time</p>
+              </div>
+            </div>
+            <div className="flex items-center justify-between sm:w-40">
+              <p className="text-slate-500"></p>
+              <Image
+                src="/more.png"
+                alt=""
+                height={0}
+                width={0}
+                className="w-3 ml-2 sm:w-4 sm:h-4"
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ConversationsList;

--- a/frontend/components/ConversationHistory/idex.tsx
+++ b/frontend/components/ConversationHistory/idex.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import useGetConversations from "@/hooks/useGetConverstaions";
+import React, { useState } from "react";
+import ConversationTitle from "./ConversationTitle";
+import ConversationsList from "./ConversationsList";
+import ConversationDrawer from "./ConversationDrawer";
+import ConversationHistoryFooter from "./ConversationHistoryFooter";
+
+const ConversationHistory = () => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [selectedConversation, setSelectedConversation] = useState<
+    string | null
+  >(null);
+
+  const [sortType, setSortType] = useState("latest");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(10);
+
+  const { conversationsList, loading } = useGetConversations({
+    token: "",
+    currentPage,
+  });
+
+  return (
+    <div className="bg-white h-screen w-full overflow-hidden">
+      <ConversationTitle
+        sortMessages={setSortType}
+        isOpen={isDropdownOpen}
+        setIsOpen={setIsDropdownOpen}
+        setIsDropdownOpen={setIsDropdownOpen}
+      />
+      <ConversationsList
+        sortType={sortType}
+        conversationsList={conversationsList}
+        setSelectedConversation={setSelectedConversation}
+        setIsDrawerOpen={setIsDrawerOpen}
+        loading={loading}
+      />
+      <ConversationDrawer
+        isDrawerOpen={isDrawerOpen}
+        handleDrawerClose={setIsDrawerOpen}
+        threadId={selectedConversation}
+      />
+      <ConversationHistoryFooter
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        totalPages={totalPages}
+      />
+    </div>
+  );
+};
+export default ConversationHistory;

--- a/frontend/components/Loaders.tsx
+++ b/frontend/components/Loaders.tsx
@@ -1,0 +1,87 @@
+import styled, { keyframes } from "styled-components";
+import React from "react";
+
+interface colorProp {
+  color: string;
+}
+
+const spinAnimation = keyframes`
+100% {
+    transform: rotate(1turn);
+ }
+`;
+
+export const Loader = styled.div<colorProp>`
+  width: 1.3rem;
+  height: 1.3rem;
+  border-radius: 50%;
+  background: ${(
+    props
+  ) => `radial-gradient(farthest-side, ${props.color} 94%,#0000) top/0.1rem 0.1rem no-repeat,
+        conic-gradient(#0000 30%, ${props.color})`};
+  -webkit-mask: radial-gradient(
+    farthest-side,
+    #0000 calc(100% - 0.2rem),
+    #000 0
+  );
+  animation: ${spinAnimation} 1s infinite linear;
+`;
+
+const pulse = keyframes`
+  0% {
+    background-position: -100% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+export const SkeletonLoader = styled.div`
+  width: 100%;
+  height: 20px;
+  background: linear-gradient(90deg, #ececec 25%, #f1f1f1 50%, #ececec 75%);
+  background-size: 200% 100%;
+  animation: ${pulse} 1.5s ease-in-out infinite;
+  border-radius: 4px;
+`;
+
+type LineProps = {
+  isLast: boolean;
+};
+
+const Line = styled.div<LineProps>`
+  width: ${({ isLast }) => (isLast ? "50%" : "100%")};
+  height: 1.2rem;
+  background: linear-gradient(90deg, #f6f6fb, white, #f6f6fb);
+  background-size: 200% 100%;
+  animation: ${pulse} 2s linear infinite;
+  border-radius: 7px;
+  margin-bottom: 1rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const MultiLineSkeletonLoader = (props: {
+  lines: number;
+  justifyContent: string;
+}) => {
+  const { lines } = props;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        display: "flex",
+        justifyContent: `${props.justifyContent}`,
+        flexWrap: "wrap",
+        marginTop: "0.5rem",
+      }}
+    >
+      {Array.from({ length: lines }).map((_, index) => (
+        <Line key={index} isLast={index === lines - 1} />
+      ))}
+    </div>
+  );
+};

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "../../utils/cn"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-full overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import { cn } from "../../utils/cn";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed backdrop-blur-sm z-50 gap-4 bg-transparent-white-75 py-2 px-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      background: {
+        white: "bg-white",
+        transparent: "bg-transparent-white-75",
+      },
+      width: {
+        full: "w-full",
+        ninety: "w-11/12",
+      },
+
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-lg",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+      background: "transparent",
+      width: "full",
+    },
+  }
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  isDrawerOpen?: boolean;
+  title?: string;
+  withTopBar?: boolean;
+  handleDrawerClose?: (isDrawerOpen: boolean) => void;
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(
+  (
+    {
+      side = "right",
+      background = "transparent",
+      width = "full",
+      className,
+      children,
+      isDrawerOpen,
+      title,
+      withTopBar,
+      handleDrawerClose,
+      ...props
+    },
+    ref
+  ) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side, background, width }))}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close
+          onClick={() => handleDrawerClose(false)}
+          className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+        >
+          <X className="h-6 w-6" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/frontend/hooks/useGetConverstaions.ts
+++ b/frontend/hooks/useGetConverstaions.ts
@@ -1,0 +1,88 @@
+import { getConversations } from "@/utils/getConversations";
+import { useState, useEffect } from "react";
+import { Conversation } from "@/types";
+interface props {
+  token: string;
+  currentPage: number;
+}
+
+const useGetConversations = ({ token, currentPage = 1 }: props) => {
+  const [conversationsList, setConversationsList] =
+    useState<Conversation[]>(dummyConversations);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    const fetchConversations = async () => {
+      if (!token) {
+        console.log("No token available, skipping conversation fetch");
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const conversations = await getConversations(currentPage, 20, token);
+        setConversationsList(conversations.data);
+        setError(null);
+      } catch (error) {
+        console.error("Error fetching conversations:", error);
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchConversations();
+  }, [currentPage, token]);
+
+  return {
+    conversationsList,
+    loading,
+    error,
+  };
+};
+
+export default useGetConversations;
+
+const dummyConversations: Conversation[] = [
+  {
+    threadId: "thread-001",
+    user: "john.doe@example.com",
+    chatbot: "ChatBot",
+    startTime: "2025-02-20T09:15:32Z",
+    lastUpdated: "2025-02-20T09:45:12Z",
+    title: "Lorem ipsum dolor sit amet",
+  },
+  {
+    threadId: "thread-002",
+    user: "jane.smith@example.com",
+    chatbot: "ChatBot",
+    startTime: "2025-02-21T14:23:45Z",
+    lastUpdated: "2025-02-21T15:01:33Z",
+    title: "Lorem ipsum consectetur adipiscing",
+  },
+  {
+    threadId: "thread-003",
+    user: "alex.johnson@example.com",
+    chatbot: "ChatBot",
+    startTime: "2025-02-22T11:05:17Z",
+    lastUpdated: "2025-02-24T08:12:56Z",
+    title: "Lorem ipsum elit sed do eiusmod",
+  },
+  {
+    threadId: "thread-004",
+    user: "sarah.williams@example.com",
+    chatbot: "ChatBot",
+    startTime: "2025-02-23T16:42:09Z",
+    lastUpdated: "2025-02-23T17:15:22Z",
+    title: "Lorem ipsum tempor incididunt",
+  },
+  {
+    threadId: "thread-005",
+    user: "michael.brown@example.com",
+    chatbot: "ChatBot",
+    startTime: "2025-02-24T10:30:00Z",
+    lastUpdated: "2025-02-25T11:45:37Z",
+    title: "Lorem ipsum ut labore et dolore",
+  },
+];

--- a/frontend/hooks/useSortedConversations.ts
+++ b/frontend/hooks/useSortedConversations.ts
@@ -1,0 +1,29 @@
+import { Conversation } from "@/types";
+interface useSortedConversationsProps {
+  sortType: string;
+  conversations: Conversation[];
+}
+
+const useSortedConversations = ({
+  conversations,
+  sortType,
+}: useSortedConversationsProps) => {
+  const sorted = [...conversations].sort((a, b) => {
+    switch (sortType) {
+      case "latest":
+        return (
+          new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()
+        );
+      case "most":
+        return 0;
+      case "least":
+        return 0;
+      default:
+        return 0;
+    }
+  });
+
+  return sorted;
+};
+
+export default useSortedConversations;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "chatbot",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@reduxjs/toolkit": "^2.5.1",
         "axios": "^1.7.9",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.4.4",
         "js-cookie": "^3.0.5",
@@ -221,6 +224,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -923,6 +964,556 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.6.tgz",
+      "integrity": "sha512-no3X7V5fD487wab/ZYSHXq3H37u4NVeLDKI/Ks724X/eEFSSEFYZxWgsIlr1UBeEyDaM29HM5x9p1Nv8DuTYPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-menu": "2.1.6",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.6.tgz",
+      "integrity": "sha512-tBBb5CXDJW3t2mo9WlO7r6GTmWV0F0uzHZVFmlRmYpiSK1CDU5IKojP1pm7oknpBOrFZx/YgBRW9oorPO2S/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-roving-focus": "1.1.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.2.tgz",
+      "integrity": "sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
@@ -1067,7 +1658,7 @@
       "version": "19.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
       "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -1436,6 +2027,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -1943,6 +2546,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2257,6 +2872,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -3298,6 +3919,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5872,6 +6502,75 @@
         }
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-type-animation": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-type-animation/-/react-type-animation-3.2.0.tgz",
@@ -7217,6 +7916,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@reduxjs/toolkit": "^2.5.1",
     "axios": "^1.7.9",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.4",
     "js-cookie": "^3.0.5",

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -22,7 +22,7 @@ type Message = {
 export interface Conversation {
   threadId: string;
   user: string;
-  avatar: string;
+  chatbot: string;
   startTime: string;
   lastUpdated: string;
   title: string;
@@ -58,12 +58,12 @@ export interface APIOrder {
 }
 
 export interface WebSocketMessage {
-  type: 'new_item' | 'session_updated';
-  order_id: string;  // ID of the specific order being updated
-  session_id: string;  // ID of the parent session
+  type: "new_item" | "session_updated";
+  order_id: string; // ID of the specific order being updated
+  session_id: string; // ID of the parent session
   table_number?: number;
-  item?: any;  // The new item being added
-  order?: OrderItem;  // The complete updated order
+  item?: any; // The new item being added
+  order?: OrderItem; // The complete updated order
 }
 
 export interface RootState {
@@ -91,4 +91,13 @@ export interface RootState {
     token: string;
     language: string;
   };
+}
+
+export interface Conversation {
+  threadId: string;
+  user: string;
+  chatbot: string;
+  startTime: string;
+  lastUpdated: string;
+  title: string;
 }

--- a/frontend/utils/getConversation.ts
+++ b/frontend/utils/getConversation.ts
@@ -1,0 +1,19 @@
+import { backend } from "@/config/apiConfig";
+
+export const getConversation = async (threadId: string) => {
+  try {
+    const conversationResponse = await fetch(
+      `${backend.serverUrl}/conversation/${threadId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    const data = await conversationResponse.json();
+    return data;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/frontend/utils/getConversations.ts
+++ b/frontend/utils/getConversations.ts
@@ -1,0 +1,35 @@
+import { backend } from "@/config/apiConfig";
+
+export const getConversations = async (
+  page = 1,
+  limit = 20,
+  token: string | null
+) => {
+  if (!token) {
+    console.error("Token is missing!");
+    return [];
+  }
+
+  try {
+    const response = await fetch(
+      `${backend.serverUrl}/conversations?page=${page}&limit=${limit}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("Fetched conversations:", data);
+    return data;
+  } catch (err) {
+    console.error("Failed to fetch the conversations:", err);
+    return [];
+  }
+};


### PR DESCRIPTION


https://github.com/user-attachments/assets/98647eb3-f484-4ff8-8ca3-e38aa7b592e6

# Add Conversation History

## Purpose
Adds a new conversation history page that allows users to view, sort, and navigate through their past conversations.

## Key Changes
- Created new `/conversations-history` route with corresponding page component
- Implemented conversation list view with sorting capabilities
- Added conversation drawer to display full conversation content
- Added pagination system for navigating through conversation history
- Created UI components for filtering and sorting conversations
